### PR TITLE
Let FEED_CONFIG to be set as an environment variable. Fixes #11

### DIFF
--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -11,7 +11,8 @@ import logging
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 
-
+# Get feed configuration from environment variable. Default to debug
+FEED_CONFIG = os.environ.get('SCRAPY_FEED_CONFIG', 'DEBUG')
 BOT_NAME = 'wsf_scraper'
 
 SPIDER_MODULES = ['wsf_scraping.spiders']
@@ -81,13 +82,11 @@ FEED_FORMAT = 'jsonlines'
 FEED_EXPORT_ENCODING = 'utf-8'
 FEED_TEMPDIR = 'var/tmp/'
 
-# Prod feed export to amazon s3 or DSX
-FEED_CONFIG = 'DSX'
-
 if FEED_CONFIG == 'S3':
-    AWS_ACCESS_KEY_ID = "______your_aws_id______"
-    AWS_SECRET_ACCESS_KEY = "______your_aws_secret______"
-    FEED_URI = 's3://__your_s3_bucket__/scraping/feeds/%(name)s/%(time)s.json'
+    AWS_ACCESS_KEY_ID = ''
+    AWS_SECRET_ACCESS_KEY = ''
+    AWS_FEED_CONTAINER = ''
+    FEED_URI = 's3://' + AWS_FEED_CONTAINER + '/%(name)s - %(time)s.json'
 
 if FEED_CONFIG == 'DSX':
     DSX_FEED_CONTAINER = 'OSProject'
@@ -105,7 +104,7 @@ else:
     FEED_URI = './results/%(name)s.json'
 
 # Lists to look for (case insensitive)
-SECTIONS_KEYWORDS_FILE = ''
+SECTIONS_KEYWORDS_FILE = './section_keywords.txt'
 
 # Keywords to look for (case insensitive)
 KEYWORDS_FILE = './keywords.txt'


### PR DESCRIPTION
Makes possible to set feed configuration (S3|DSX|DEBUG) via the SCRAPY_FEED_CONFIG environment variable.
Also cleans up the settings.